### PR TITLE
Fix import and add simple api test 

### DIFF
--- a/src/api/results.jl
+++ b/src/api/results.jl
@@ -1,3 +1,4 @@
+include("../apparent_temperatures.jl")
 """
 Empirical estimate of vapor pressure: https://en.wikipedia.org/wiki/Vapour_pressure_of_water
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Unitful:s,minute,°F, inch, ft,lb, g,kg,cm, Length, Area, W, J, kJ, m,Energy, kW, 
     uconvert, Power, K, Temperature, σ, Time, hr, Pressure, Pa, g, R, Mass, atm, ustrip
 using SaunaModel:Room, Stove, SaunaNoWater, SaunaScenario, SteamThrowing, solve_sauna, SaunaDefaults
+using SaunaModel:json_api
 
 results = solve_sauna(SaunaDefaults.default_scenario)
+
+json_api("{}")


### PR DESCRIPTION
Without the code fix, the test errors with 
```
(SaunaModel) pkg> test
   Testing SaunaModel
 Resolving package versions...
ERROR: LoadError: UndefVarError: _heat_into_humans not defined
Stacktrace:
 [1] extract_results(::SaunaModel.SaunaResults, ::SaunaScenario) at /Users/mark/Sauna/SaunaModel.jl/src/api/results.jl:25
 [2] dictionary_api(::Dict{String,Any}) at /Users/mark/Sauna/SaunaModel.jl/src/api/api.jl:22
 [3] json_api(::String) at /Users/mark/Sauna/SaunaModel.jl/src/api/api.jl:27
 [4] top-level scope at none:0
 [5] include at ./boot.jl:317 [inlined]
 [6] include_relative(::Module, ::String) at ./loading.jl:1038
 [7] include(::Module, ::String) at ./sysimg.jl:29
 [8] include(::String) at ./client.jl:388
 [9] top-level scope at none:0
in expression starting at /Users/mark/Sauna/SaunaModel.jl/test/runtests.jl:8
ERROR: Package SaunaModel errored during testing
```